### PR TITLE
chore: Alterado porta para 5433 para evitar conflitos

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   db-postgres-task-io:
     image: postgres:16.2-alpine3.19
     ports:
-      - 5432:5432
+      - 5433:5432
     container_name: "api-task-io"
     volumes:
       - ./db-task-io:/var/lib/postgresql/data


### PR DESCRIPTION
- Alterado para utilizar uma porta diferente da 5432 para evitar conflito com o client instalado do postgres