### PR TITLE
fix: Query rota de tarefas

### DIFF
--- a/src/controllers/TasksController.js
+++ b/src/controllers/TasksController.js
@@ -117,7 +117,7 @@ exports.getMy = async (req, res, next) => {
   try {
     const userId = req.user.id;
 
-    const tasks = await Task.findAll({ where: userId });
+    const tasks = await Task.findAll({ where: { userId: userId } });
 
     if (!tasks) {
       next(new AppError('Sem tarefas cadastradas.', 404));


### PR DESCRIPTION
Ajuste na query da rota GET /tasks/my - estava filtrando por id em vez de userId.